### PR TITLE
attempt to fix librarian puppet error on fetchcrl

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
       "version_requirement": "\u003e\u003d4.1.0"
     },
     {
-      "name": "cernops/fetchcrl",
-      "version_requirement": "\u003e\u003d0.0.2"
+      "name": "CERNOps/fetchcrl",
+      "version_requirement": "\u003e\u003d0.1.0"
     },
     {
       "name": "puppetlabs/concat",
       "version_requirement": "\u003e\u003d1.0.0"
     },
     {
-      "name": "cernops/vosupport",
+      "name": "CERNOps/vosupport",
       "version_requirement": "\u003e\u003d0.0.1"
     }
   ],


### PR DESCRIPTION
Hi,

The metadata asked for old /nonexisting CERNOps modules versions (fetchcrl mainly), and CERNOps was spelled "cernops" (lowercase), causing issues with librarian puppet.
This fixes it
