### PR TITLE
Glexec and repository

### DIFF
--- a/manifests/argus.pp
+++ b/manifests/argus.pp
@@ -1,10 +1,17 @@
 class glexecwn::argus (
   $argus_server    = $glexecwn::params::argus_server,
   $argus_port      = $glexecwn::params::argus_port,
-  $user_white_list = $glexecwn::params::user_white_list) {
+  $user_white_list = $glexecwn::params::user_white_list,
+  $template_glexec_conf = 'glexecwn/glexec.conf.erb',
+  $template_lcmaps_db   = 'glexecwn/lcmaps-glexec.db.erb',
+  $loglevel_glexec = 3,
+  $loglevel_lcmaps = 1,
+  $loglevel_lcas   = 1,
+  $loglevel_debug  = 1, #this is for various debuf log levels in the config
+  ) {
   file { '/etc/glexec.conf':
     ensure  => present,
-    content => template('glexecwn/glexec.conf.erb'),
+    content => template($template_glexec_conf),
     owner   => 'root',
     group   => 'glexec',
     mode    => 0640,
@@ -12,7 +19,7 @@ class glexecwn::argus (
 
   file { '/etc/lcmaps/lcmaps-glexec.db':
     ensure  => present,
-    content => template('glexecwn/lcmaps-glexec.db.erb'),
+    content => template($template_lcmaps_db),
     owner   => 'root',
     group   => 'root',
     mode    => 0640,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,7 @@ class glexecwn (
   $argus_port         = $glexecwn::params::argus_port,
   $argus_server       = $glexecwn::params::argus_server,
   $emi_version        = $glexecwn::params::emi_version,
+  $emi_repos_ensure   = 'present',
   $glexec_location    = $glexecwn::params::glexec_location,
   $glexec_permissions = $glexecwn::params::glexec_permissions,
   $glite_env_set      = $glexecwn::params::glite_env_set,
@@ -24,7 +25,7 @@ class glexecwn (
     RedHat, SLC, SL, Scientific : {
       require fetchcrl
 
-      class { 'glexecwn::repositories': emi_version => $emi_version, }
+      class { 'glexecwn::repositories': ensure => $emi_repos_ensure, emi_version => $emi_version, }
 
       class { 'glexecwn::install':
         emi_version        => $emi_version,
@@ -59,8 +60,7 @@ class glexecwn (
       class { 'glexecwn::wninfo':
       }
 
-      Class['glexecwn::repositories'] -> Class['glexecwn::install'] -> Class['glexecwn::config'
-        ]
+      Class['glexecwn::install'] -> Class['glexecwn::config' ]
     }
     default                     : {
       # There is some fedora configuration present but I can't actually get it

--- a/manifests/repositories.pp
+++ b/manifests/repositories.pp
@@ -1,52 +1,59 @@
 class glexecwn::repositories (
-  $emi_version = glexecwn::params::emi_version) {
+  $ensure      = 'present', #allows site admin to disable those repositories, if already present in their config.
+  $emi_version = glexecwn::params::emi_version,
+  ) {
   #
   # ensure that we get everything from EMI and not mix with EPEL unless we need
   # stuff from there
   #
-
-  #  include 'emirepos::emi2repositories'
-  $major_release = regsubst($::operatingsystemrelease, '^(\d+)\.\d+$', '\1')
-
-  yumrepo { "EMI_${emi_version}_base":
-    name     => "emi-${emi_version}-base",
-    descr    => 'EMI - $basearch - base',
-    baseurl  => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/sl${major_release}/\$basearch/base",
-    gpgcheck => 1,
-    gpgkey   => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/RPM-GPG-KEY-emi",
-    enabled  => 1,
-    priority => 40,
-  }
-
-  yumrepo { "EMI_${emi_version}_contribs":
-    name     => "emi-${emi_version}-contribs",
-    descr    => 'EMI - $basearch - contribs',
-    baseurl  => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/sl${major_release}/\$basearch/contribs",
-    gpgcheck => 1,
-    gpgkey   => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/RPM-GPG-KEY-emi",
-    enabled  => 1,
-    priority => 40,
-  }
-
-  yumrepo { "EMI_${emi_version}_third-party":
-    name     => "emi-${emi_version}-third-party",
-    descr    => 'EMI - $basearch - third-party',
-    baseurl  => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/sl${major_release}/\$basearch/third-party",
-    gpgcheck => 1,
-    gpgkey   => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/RPM-GPG-KEY-emi",
-    enabled  => 1,
-    priority => 40,
-  }
-
-  yumrepo { "EMI_${emi_version}_updates":
-    name     => "emi-${emi_version}-updates",
-    descr    => 'EMI - $basearch - updates',
-    baseurl  => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/sl${major_release}/\$basearch/updates",
-    gpgcheck => 1,
-    gpgkey   => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/RPM-GPG-KEY-emi",
-    enabled  => 1,
-    priority => 40,
-  }
+  
+  if($ensure == 'present') {
+  
+    Class['glexecwn::repositories'] -> Class['glexecwn::install']
+  
+    #  include 'emirepos::emi2repositories'
+    $major_release = regsubst($::operatingsystemrelease, '^(\d+)\.\d+$', '\1')
+  
+    yumrepo { "EMI_${emi_version}_base":
+      name     => "emi-${emi_version}-base",
+      descr    => 'EMI - $basearch - base',
+      baseurl  => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/sl${major_release}/\$basearch/base",
+      gpgcheck => 1,
+      gpgkey   => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/RPM-GPG-KEY-emi",
+      enabled  => 1,
+      priority => 40,
+    }
+  
+    yumrepo { "EMI_${emi_version}_contribs":
+      name     => "emi-${emi_version}-contribs",
+      descr    => 'EMI - $basearch - contribs',
+      baseurl  => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/sl${major_release}/\$basearch/contribs",
+      gpgcheck => 1,
+      gpgkey   => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/RPM-GPG-KEY-emi",
+      enabled  => 1,
+      priority => 40,
+    }
+  
+    yumrepo { "EMI_${emi_version}_third-party":
+      name     => "emi-${emi_version}-third-party",
+      descr    => 'EMI - $basearch - third-party',
+      baseurl  => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/sl${major_release}/\$basearch/third-party",
+      gpgcheck => 1,
+      gpgkey   => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/RPM-GPG-KEY-emi",
+      enabled  => 1,
+      priority => 40,
+    }
+  
+    yumrepo { "EMI_${emi_version}_updates":
+      name     => "emi-${emi_version}-updates",
+      descr    => 'EMI - $basearch - updates',
+      baseurl  => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/sl${major_release}/\$basearch/updates",
+      gpgcheck => 1,
+      gpgkey   => "http://emisoft.web.cern.ch/emisoft/dist/EMI/${emi_version}/RPM-GPG-KEY-emi",
+      enabled  => 1,
+      priority => 40,
+    }
+  } #end of ensure
 
   #
   # upgrade path conflicts

--- a/templates/glexec.conf.erb
+++ b/templates/glexec.conf.erb
@@ -3,21 +3,21 @@
 #
 [glexec]
 silent_logging               = no
-log_level                    = 3
+log_level                    = <%= @loglevel_glexec %>
 user_white_list              = <%=@user_white_list%>
 linger                       = yes
 user_identity_switch_by      = glexec
 use_lcas                     = no
 lcmaps_db_file               = /etc/lcmaps/lcmaps-glexec.db
 lcmaps_log_file              = /var/log/glexec/lcas_lcmaps.log
-lcmaps_debug_level           = 1
-lcmaps_log_level             = 1
+lcmaps_debug_level           = <%= @loglevel_debug %>
+lcmaps_log_level             = <%= @loglevel_lcmaps %>
 lcmaps_get_account_policy    = glexec_get_account
 lcmaps_verify_account_policy = glexec_verify_account
 
 lcas_db_file                 = /etc/lcas/lcas-glexec.db
 lcas_log_file                = /var/log/glexec/lcas_lcmaps.log
-lcas_debug_level             = 1
-lcas_log_level               = 1
+lcas_debug_level             = <%= @loglevel_debug %>
+lcas_log_level               = <%= @loglevel_lcas %>
 preserve_env_variables       = no
 log_destination              = syslog

--- a/templates/lcmaps-glexec.db.condor.erb
+++ b/templates/lcmaps-glexec.db.condor.erb
@@ -1,0 +1,34 @@
+#
+# This lcmaps config will make use of Brian Bockelman's "MOUNT_UNDER_SCRATCH" plugin, that fixes the htcnodor issue of 
+# bind mounting /tmp in the job directories only with the user permissions, thus causing glexec to malfunction and 
+# error out with this kind of error :
+#
+#Feb 15 05:39:21 wn274 glexec[97852]: Failed to write proxyfile /tmp/x509up_u4981.glexec.17556.
+#Feb 15 05:39:21 wn274 glexec[97852]:   errno (13): Permission denied
+#Feb 15 05:39:21 wn274 glexec[97852]:   Failure writing proxy file
+#
+# you will *NEED* to get your hands on a compiled version of this module
+#
+# See : https://github.com/bbockelm/lcmaps-plugins-mount-under-scratch
+#
+# where to look for modules
+path = /usr/lib64/lcmaps
+
+# module definitions
+verify_proxy = "lcmaps_verify_proxy.mod"
+               " -certdir /etc/grid-security/certificates/"
+               " --allow-limited-proxy"
+
+pepc        = "lcmaps_c_pep.mod"
+              "--pep-daemon-endpoint-url https://<%=@argus_server%>:<%=@argus_port%>/authz"
+              " -resourceid http://authz-interop.org/xacml/resource/resource-type/wn"
+              " -actionid http://glite.org/xacml/action/execute"
+              " -capath /etc/grid-security/certificates/"
+              " -pep-certificate-mode implicit"
+              " --use-pilot-proxy-as-cafile" # Add this on RHEL 6 based systems
+
+mkdir = "lcmaps_mount_under_scratch.mod"
+
+glexec_get_account:
+verify_proxy -> pepc
+pepc -> mkdir


### PR DESCRIPTION
Adding options to allow for specifying the glexec lcmaps templates. Not perfect, because adding new arguents would mean to add those too in all parent classes and I haven't done this, but this can at least be used with hiera. I don't know if that'd be a good thing to bring back all the arguments of the subclasses into the main class.

Anyway. This adds too the possibility to change the glexec/lcmaps/lcas debugging level, and this finally adds the possibility NOT to setup the EMI repositories as this can be done in many outside modules, and that surely breaks our setup here.
